### PR TITLE
Added index.d.ts types for the package

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { AxeResults, RunOnly } from "axe-core";
+import { AxeResults, Result, RunOnly } from "axe-core";
 
 /**
  * Version of the aXe verifier with defaults set.
@@ -36,13 +36,19 @@ export type JestAxe = (html: string, options?: AxeOptions) => Promise<AxeResults
  */
 export const configureAxe: (options: AxeOptions) => JestAxe;
 
+export interface AssertionsResult {
+    actual: Result[];
+    message(): string;
+    pass: boolean;
+}
+
 /**
  * Asserts an aXe-verified result has no violations.
  *
+ * @param results   aXe verification result, if not running via expect().
  * @returns Jest expectations for the aXe result.
- * @remarks Must be called on an expect wrapping an aXe results object.
  */
-export type IToHaveNoViolations = () => { message(): string, pass: boolean };
+export type IToHaveNoViolations = (results?: Partial<AxeResults>) => AssertionsResult;
 
 export const toHaveNoViolations: {
     toHaveNoViolations: IToHaveNoViolations;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,9 +36,23 @@ export type JestAxe = (html: string, options?: AxeOptions) => Promise<AxeResults
  */
 export const configureAxe: (options: AxeOptions) => JestAxe;
 
+/**
+ * Results from asserting whether aXe verification passed.
+ */
 export interface AssertionsResult {
+    /**
+     * Actual checked aXe verification results.
+     */
     actual: Result[];
+
+    /**
+     * @returns Message from the Jest assertion.
+     */
     message(): string;
+
+    /**
+     * Whether the assertion passed.
+     */
     pass: boolean;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,57 @@
+import { AxeResults, RunOnly } from "axe-core";
+
+/**
+ * Version of the aXe verifier with defaults set.
+ * 
+ * @remarks You can still pass additional options to this new instance;
+ *          they will be merged with the defaults.
+ */
+export const axe: JestAxe;
+
+/**
+ * Core options to run aXe.
+ */
+export interface AxeOptions {
+    runOnly?: RunOnly;
+    rules?: object;
+    iframes?: boolean;
+    elementRef?: boolean;
+    selectors?: boolean;
+}
+
+/**
+ * Runs aXe on HTML.
+ * 
+ * @param html   Raw HTML string to verify with aXe.
+ * @param options   Options to run aXe.
+ * @returns Promise for the results of running aXe.
+ */
+export type JestAxe = (html: string, options?: AxeOptions) => Promise<AxeResults>;
+
+/**
+ * Creates a new aXe verifier function.
+ * 
+ * @param options   Options to run aXe.
+ * @returns New aXe verifier function.
+ */
+export const configureAxe: (options: AxeOptions) => JestAxe;
+
+/**
+ * Asserts an aXe-verified result has no violations.
+ *
+ * @returns Jest expectations for the aXe result.
+ * @remarks Must be called on an expect wrapping an aXe results object.
+ */
+export type IToHaveNoViolations = () => { message(): string, pass: boolean };
+
+export const toHaveNoViolations: {
+    toHaveNoViolations: IToHaveNoViolations;
+};
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toHaveNoViolations: IToHaveNoViolations;
+        }
+    }
+}

--- a/index.test.js
+++ b/index.test.js
@@ -82,7 +82,8 @@ describe('jest-axe', () => {
 
     it('throws with non-string input', () => {
       expect(() => {
-        axe({})
+        // @ts-ignore
+        axe({}) 
       }).toThrow('html parameter should be a string not a object')
     })
 
@@ -93,6 +94,7 @@ describe('jest-axe', () => {
     })
   })
   describe('toHaveNoViolations', () => {
+    /** @type Object */
     const failingAxeResults = {
       violations: [
         {
@@ -178,6 +180,7 @@ describe('jest-axe', () => {
     it('throws error if non axe results object is passed', () => {
       const matcherFunction = toHaveNoViolations.toHaveNoViolations
       expect(() => {
+        // @ts-ignore
         matcherFunction({})
       }).toThrow('No violations found in aXe results object')
     })

--- a/index.test.js
+++ b/index.test.js
@@ -83,7 +83,7 @@ describe('jest-axe', () => {
     it('throws with non-string input', () => {
       expect(() => {
         // @ts-ignore
-        axe({}) 
+        axe({})
       }).toThrow('html parameter should be a string not a object')
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,18 @@
         "js-tokens": "3.0.2"
       }
     },
+    "@types/jest": {
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.1.2.tgz",
+      "integrity": "sha512-CJE7jEc0WjCdyG7clSc1V7uSRcdEd5gGB84/kajAH+6QGfT/YERezwENmuAZK0/N6qu0RZsUobj7q7y93vyMYQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.5.tgz",
+      "integrity": "sha512-DvC7bzO5797bkApgukxouHmkOdYN2D0yL5olw0RncDpXUa6n39qTVsUi/5g2QJjPgl8qn4zh+4h0sofNoWGLRg==",
+      "dev": true
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -5249,6 +5261,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "standard && jest && test:types",
+    "test": "standard && jest && npm run test:types",
     "test:types": "tsc --project tsconfig.test.json"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "standard && jest"
+    "test": "standard && jest && test:types",
+    "test:types": "tsc --project tsconfig.test.json"
   },
   "keywords": [
     "jest",
@@ -26,7 +27,10 @@
     "lodash.merge": "^4.6.1"
   },
   "devDependencies": {
+    "@types/jest": "^22.1.2",
+    "@types/node": "^9.4.5",
     "jest": "^22.2.2",
-    "standard": "^10.0.3"
+    "standard": "^10.0.3",
+    "typescript": "^2.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Custom Jest matcher for aXe for testing accessibility",
   "repository": "nickcolley/jest-axe",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "standard && jest"
   },

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "baseUrl": ".",
+        "checkJs": true,
+        "lib": [
+            "dom",
+            "es2015"
+        ],
+        "noEmit": true,
+        "paths": {
+            "jest-axe": ["./index.d.ts"]
+        },
+        "pretty": true
+    },
+    "include": [
+        "./index.test.js"
+    ]
+}


### PR DESCRIPTION
This was a little trickier than I thought, since it needs to both declare itself as a module named `"jest-axe"` and augment a global `jest` `namespace`. 

Prior art for `jest` changing: https://github.com/FormidableLabs/enzyme-matchers/blob/master/packages/jest-enzyme/src/index.d.ts

Docs for global augmentation: http://www.typescriptlang.org/docs/handbook/declaration-merging.html#global-augmentation

Fixes #1