### PR TITLE
Make engines requirement less strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Nick Colley",
   "license": "MIT",
   "engines": {
-    "node": "8.9.4"
+    "node": ">= 8.9.4"
   },
   "dependencies": {
     "axe-core": "^2.6.1",


### PR DESCRIPTION
## Changesp

- Change Node version requirement from `equal` to `greater than or equal` (→ [documentation](https://docs.npmjs.com/files/package.json#engines))

**Question**: Is `v8.9.4` really the first version of Node that's supported, or could this be lower?

Closes #12.