### PR TITLE
Remove the word 'simply'

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ it('should demonstrate this matcher`s usage', async () => {
 
 ![Screenshot of the resulting output from the usage example](example-cli.png)
 
-> Note, you can also simply require `'jest-axe/extend-expect'` which will call `expect.extend` for you.
+> Note, you can also require `'jest-axe/extend-expect'` which will call `expect.extend` for you.
 > This is especially helpful when using the jest `setupTestFrameworkScriptFile` configuration.
 
 ### With React

--- a/extend-expect.js
+++ b/extend-expect.js
@@ -1,7 +1,13 @@
-// this allows users to simply add `require('jest-axe/extend-expect')`
-// at the top of their test file rather than have two lines for this.
-// it also allows users to use jest's setupFiles configuration and
-// point directly to `jest-axe/extend-expect`
+/* 
+
+This allows users to add `require('jest-axe/extend-expect')
+at the top of their test file rather than have two lines for this.
+
+It also allows users to use jest's setupFiles configuration and
+point directly to `jest-axe/extend-expect`
+
+*/
+
 const { toHaveNoViolations } = require('jest-axe')
 
 expect.extend(toHaveNoViolations)

--- a/extend-expect.js
+++ b/extend-expect.js
@@ -1,6 +1,6 @@
 /* 
 
-This allows users to add `require('jest-axe/extend-expect')
+This allows users to add `require('jest-axe/extend-expect')`
 at the top of their test file rather than have two lines for this.
 
 It also allows users to use jest's setupFiles configuration and


### PR DESCRIPTION
When things go wrong, words that imply things are easy are very frustrating.