### PR TITLE
Don't mutate document.body when running axe

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,13 @@ function configureAxe (defaultOptions = {}) {
       throw new Error(`html parameter ("${html}") has no elements`)
     }
 
+    // Before we use Jests's jsdom document we store and remove all child nodes from the body.
+    const bodyChilds = document.createElement('div');
+    document.body.childNodes.forEach(child => {
+      document.body.removeChild(child)
+      bodyChilds.appendChild(child)
+    })
+
     // aXe requires real Nodes so we need to inject into Jests' jsdom document.
     document.body.innerHTML = html
 
@@ -36,8 +43,14 @@ function configureAxe (defaultOptions = {}) {
 
     return new Promise((resolve, reject) => {
       axeCore.run(document.body, options, (err, results) => {
-        if (err) throw err
+        // In any case we restore the contents of the body by appending its childs again.
         document.body.innerHTML = ''
+        bodyChilds.childNodes.forEach(child => {
+          bodyChilds.remove(child)
+          document.body.appendChild(child)
+        })
+
+        if (err) throw err
         resolve(results)
       })
     })

--- a/index.js
+++ b/index.js
@@ -30,25 +30,18 @@ function configureAxe (defaultOptions = {}) {
     }
 
     // Before we use Jests's jsdom document we store and remove all child nodes from the body.
-    const bodyChilds = document.createElement('div');
-    document.body.childNodes.forEach(child => {
-      document.body.removeChild(child)
-      bodyChilds.appendChild(child)
-    })
+    const axeContainer = document.createElement('div');
+    axeContainer.innerHTML = html
 
     // aXe requires real Nodes so we need to inject into Jests' jsdom document.
-    document.body.innerHTML = html
+    document.body.appendChild(axeContainer)
 
     const options = merge({}, defaultOptions, additionalOptions)
 
     return new Promise((resolve, reject) => {
-      axeCore.run(document.body, options, (err, results) => {
-        // In any case we restore the contents of the body by appending its childs again.
-        document.body.innerHTML = ''
-        bodyChilds.childNodes.forEach(child => {
-          bodyChilds.remove(child)
-          document.body.appendChild(child)
-        })
+      axeCore.run(axeContainer, options, (err, results) => {
+        // In any case we restore the contents of the body by removing the additional element again.
+        document.body.removeChild(axeContainer)
 
         if (err) throw err
         resolve(results)

--- a/index.test.js
+++ b/index.test.js
@@ -57,9 +57,11 @@ describe('jest-axe', () => {
       expect(typeof results.violations).toBe('object')
     })
 
-    it('clears the document body after recieving axe results', async () => {
-      await axe(failingHtmlExample)
-      expect(document.body.innerHTML).toBe('')
+    it('should not mutate the content of document.body permanently', async () => {
+      const el = document.body.appendChild(document.createElement("div"))
+      await axe(goodHtmlExample)
+      expect(document.body.childElementCount).toBe(1);
+      expect(document.body.firstChild).toBe(el);
     })
 
     it('returns violations for failing html example', async () => {


### PR DESCRIPTION
This PR relates to #50.

Instead of clearing the contents of `document.body` I propose to copy the contents to another DOM element. After `axe` did finish we can insert them back into the body.

Note that it doesn't work to just clone the body (ie. by using `document.body.cloneNode`). This is the case because `react-testing-library` internally holds references to the elements it rendered. If these references are gone then `unmount` or `cleanup` won't work.

I also moved up the reseting of the body before throwing the error, so we can be sure that it happens in any case.