### PR TITLE
updated violation output to display a list of fixes for each node

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -5,13 +5,22 @@ exports[`jest-axe readme first readme example should demonstrate this matcher\`s
 
 Expected the HTML found at $('img') to have no violations:
 
-<img src=\\"#\\">
+[90m<img src=\\"#\\">[39m
 
 Received:
 
 [31m\\"Images must have alternate text (image-alt)\\"[39m
 
-Try fixing it with this help: https://dequeuniversity.com/rules/axe/3.1/image-alt?application=axeAPI"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute or the title attribute is empty[39m
+[33m  Element's default semantics were not overridden with role=\\"presentation\\"[39m
+[33m  Element's default semantics were not overridden with role=\\"none\\"[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/3.1/image-alt?application=axeAPI[39m"
 `;
 
 exports[`jest-axe readme readme react example renders correctly 1`] = `
@@ -19,13 +28,22 @@ exports[`jest-axe readme readme react example renders correctly 1`] = `
 
 Expected the HTML found at $('img') to have no violations:
 
-<img src=\\"#\\" data-reactroot=\\"\\">
+[90m<img src=\\"#\\" data-reactroot=\\"\\">[39m
 
 Received:
 
 [31m\\"Images must have alternate text (image-alt)\\"[39m
 
-Try fixing it with this help: https://dequeuniversity.com/rules/axe/3.1/image-alt?application=axeAPI"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute or the title attribute is empty[39m
+[33m  Element's default semantics were not overridden with role=\\"presentation\\"[39m
+[33m  Element's default semantics were not overridden with role=\\"none\\"[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/3.1/image-alt?application=axeAPI[39m"
 `;
 
 exports[`jest-axe toHaveNoViolations returns correctly formatted message when violations are present 1`] = `
@@ -33,13 +51,22 @@ exports[`jest-axe toHaveNoViolations returns correctly formatted message when vi
 
 Expected the HTML found at $('body > img') to have no violations:
 
-<img src=\\"\\">
+[90m<img src=\\"\\">[39m
 
 Received:
 
 [31m\\"Images must have alternate text (image-alt)\\"[39m
 
-Try fixing it with this help: https://dequeuniversity.com/rules/axe/2.6/image-alt?application=axeAPI"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty or not visible[39m
+[33m  Element has no title attribute or the title attribute is empty[39m
+[33m  Element's default semantics were not overridden with role=\\"presentation\\"[39m
+[33m  Element's default semantics were not overridden with role=\\"none\\"[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/2.6/image-alt?application=axeAPI[39m"
 `;
 
 exports[`jest-axe toHaveNoViolations returns properly formatted text with more complex example 1`] = `
@@ -47,59 +74,133 @@ exports[`jest-axe toHaveNoViolations returns properly formatted text with more c
 
 Expected the HTML found at $('img[src$=\\"example.com\\"]') to have no violations:
 
-<img src=\\"http://example.com\\">
-
-Expected the HTML found at $('img[src=\\"http://example.com/2\\"]') to have no violations:
-
-<img src=\\"http://example.com/2\\">
+[90m<img src=\\"http://example.com\\">[39m
 
 Received:
 
 [31m\\"Images must have alternate text (image-alt)\\"[39m
 
-Try fixing it with this help: https://dequeuniversity.com/rules/axe/3.1/image-alt?application=axeAPI
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute or the title attribute is empty[39m
+[33m  Element's default semantics were not overridden with role=\\"presentation\\"[39m
+[33m  Element's default semantics were not overridden with role=\\"none\\"[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/3.1/image-alt?application=axeAPI[39m
+
+Expected the HTML found at $('img[src=\\"http://example.com/2\\"]') to have no violations:
+
+[90m<img src=\\"http://example.com/2\\">[39m
+
+Received:
+
+[31m\\"Images must have alternate text (image-alt)\\"[39m
+
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute or the title attribute is empty[39m
+[33m  Element's default semantics were not overridden with role=\\"presentation\\"[39m
+[33m  Element's default semantics were not overridden with role=\\"none\\"[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/3.1/image-alt?application=axeAPI[39m
 
 ────────
 
 Expected the HTML found at $('input') to have no violations:
 
-<input type=\\"text\\">
+[90m<input type=\\"text\\">[39m
 
 Received:
 
 [31m\\"Form elements must have labels (label)\\"[39m
 
-Try fixing it with this help: https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI
+[33mFix any of the following:[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Form element does not have an implicit (wrapped) <label>[39m
+[33m  Form element does not have an explicit <label>[39m
+[33m  Element has no title attribute or the title attribute is empty[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI[39m
 
 ────────
 
 Expected the HTML found at $('a[href$=\\"#link-name\\"]') to have no violations:
 
-<a href=\\"#link-name\\"></a>
-
-Expected the HTML found at $('a[href$=\\"#link-name-2\\"]') to have no violations:
-
-<a href=\\"#link-name-2\\"></a>
+[90m<a href=\\"#link-name\\"></a>[39m
 
 Received:
 
 [31m\\"Links must have discernible text (link-name)\\"[39m
 
-Try fixing it with this help: https://dequeuniversity.com/rules/axe/3.1/link-name?application=axeAPI
+[33mFix all of the following:[39m
+[33m  Element is in tab order and does not have accessible text[39m
+[33m[39m
+[33mFix any of the following:[39m
+[33m  Element does not have text that is visible to screen readers[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element's default semantics were not overridden with role=\\"presentation\\"[39m
+[33m  Element's default semantics were not overridden with role=\\"none\\"[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/3.1/link-name?application=axeAPI[39m
+
+Expected the HTML found at $('a[href$=\\"#link-name-2\\"]') to have no violations:
+
+[90m<a href=\\"#link-name-2\\"></a>[39m
+
+Received:
+
+[31m\\"Links must have discernible text (link-name)\\"[39m
+
+[33mFix all of the following:[39m
+[33m  Element is in tab order and does not have accessible text[39m
+[33m[39m
+[33mFix any of the following:[39m
+[33m  Element does not have text that is visible to screen readers[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element's default semantics were not overridden with role=\\"presentation\\"[39m
+[33m  Element's default semantics were not overridden with role=\\"none\\"[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/3.1/link-name?application=axeAPI[39m
 
 ────────
 
 Expected the HTML found at $('a[href$=\\"#link-name\\"]') to have no violations:
 
-<a href=\\"#link-name\\"></a>
-
-Expected the HTML found at $('a[href$=\\"#link-name-2\\"]') to have no violations:
-
-<a href=\\"#link-name-2\\"></a>
+[90m<a href=\\"#link-name\\"></a>[39m
 
 Received:
 
 [31m\\"The skip-link target should exist and be focusable (skip-link)\\"[39m
 
-Try fixing it with this help: https://dequeuniversity.com/rules/axe/3.1/skip-link?application=axeAPI"
+[33mFix any of the following:[39m
+[33m  No skip link target[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/3.1/skip-link?application=axeAPI[39m
+
+Expected the HTML found at $('a[href$=\\"#link-name-2\\"]') to have no violations:
+
+[90m<a href=\\"#link-name-2\\"></a>[39m
+
+Received:
+
+[31m\\"The skip-link target should exist and be focusable (skip-link)\\"[39m
+
+[33mFix any of the following:[39m
+[33m  No skip link target[39m
+
+You can find more information on this issue here: 
+[34mhttps://dequeuniversity.com/rules/axe/3.1/skip-link?application=axeAPI[39m"
 `;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const axeCore = require('axe-core')
 const merge = require('lodash.merge')
+const chalk = require('chalk')
 const { printReceived, matcherHint } = require('jest-matcher-utils')
 
 /**
@@ -73,24 +74,25 @@ const toHaveNoViolations = {
       const horizontalLine = '\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500'
 
       return violations.map(violation => {
-        const htmlAndTarget = violation.nodes.map(node => {
+        const errorBody = violation.nodes.map(node => {
           const selector = node.target.join(', ')
+          const expectedText = `Expected the HTML found at $('${selector}') to have no violations:` + lineBreak
           return (
-            `Expected the HTML found at $('${selector}') to have no violations:` +
+            expectedText +
+            chalk.grey(node.html) +
             lineBreak +
-            node.html
+            `Received:` +
+            lineBreak +
+            printReceived(`${violation.help} (${violation.id})`) +
+            lineBreak +
+            chalk.yellow(node.failureSummary) +
+            lineBreak +
+            `You can find more information on this issue here: \n` +
+            chalk.blue(violation.helpUrl)
           )
         }).join(lineBreak)
 
-        return (
-          htmlAndTarget +
-          lineBreak +
-          `Received:` +
-          lineBreak +
-          printReceived(`${violation.help} (${violation.id})`) +
-          lineBreak +
-          `Try fixing it with this help: ${violation.helpUrl}`
-        )
+        return (errorBody)
       }).join(lineBreak + horizontalLine + lineBreak)
     }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "axe-core": "3.1.2",
     "chalk": "^2.4.2",
     "jest-matcher-utils": "24.0.0",
-    "lodash.merge": "4.6.1"
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "async-to-gen": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "axe-core": "3.1.2",
+    "chalk": "^2.4.2",
     "jest-matcher-utils": "24.0.0",
     "lodash.merge": "4.6.1"
   },


### PR DESCRIPTION
This PR updates the console output on violations to include the list of suggested fixes for each affected node. This also adds some slight formatting changes.

![image](https://user-images.githubusercontent.com/20845740/58435681-84fd2b00-80b9-11e9-9b42-60009470c527.png)

Addresses #63 