### PR TITLE
Update axe-core to 3.4.1

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -20,7 +20,7 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/image-alt?application=axeAPI[39m"
+[34mhttps://dequeuniversity.com/rules/axe/3.4/image-alt?application=axeAPI[39m"
 `;
 
 exports[`jest-axe toHaveNoViolations returns correctly formatted message when violations are present 1`] = `
@@ -66,7 +66,7 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/image-alt?application=axeAPI[39m
+[34mhttps://dequeuniversity.com/rules/axe/3.4/image-alt?application=axeAPI[39m
 
 Expected the HTML found at $('img[src=\\"http\\\\:\\\\/\\\\/example\\\\.com\\\\/2\\"]') to have no violations:
 
@@ -85,7 +85,7 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/image-alt?application=axeAPI[39m
+[34mhttps://dequeuniversity.com/rules/axe/3.4/image-alt?application=axeAPI[39m
 
 ────────
 
@@ -105,7 +105,7 @@ Received:
 [33m  Element has no title attribute or the title attribute is empty[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/label?application=axeAPI[39m
+[34mhttps://dequeuniversity.com/rules/axe/3.4/label?application=axeAPI[39m
 
 ────────
 
@@ -128,7 +128,7 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/link-name?application=axeAPI[39m
+[34mhttps://dequeuniversity.com/rules/axe/3.4/link-name?application=axeAPI[39m
 
 Expected the HTML found at $('a[href$=\\"\\\\#link-name-2\\"]') to have no violations:
 
@@ -149,7 +149,7 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/link-name?application=axeAPI[39m
+[34mhttps://dequeuniversity.com/rules/axe/3.4/link-name?application=axeAPI[39m
 
 ────────
 
@@ -165,7 +165,7 @@ Received:
 [33m  No skip link target[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/skip-link?application=axeAPI[39m
+[34mhttps://dequeuniversity.com/rules/axe/3.4/skip-link?application=axeAPI[39m
 
 Expected the HTML found at $('a[href$=\\"\\\\#link-name-2\\"]') to have no violations:
 
@@ -179,5 +179,5 @@ Received:
 [33m  No skip link target[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/skip-link?application=axeAPI[39m"
+[34mhttps://dequeuniversity.com/rules/axe/3.4/skip-link?application=axeAPI[39m"
 `;

--- a/__tests__/__snapshots__/reactjs.test.js.snap
+++ b/__tests__/__snapshots__/reactjs.test.js.snap
@@ -20,7 +20,7 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/image-alt?application=axeAPI[39m"
+[34mhttps://dequeuniversity.com/rules/axe/3.4/image-alt?application=axeAPI[39m"
 `;
 
 exports[`React renders correctly 1`] = `
@@ -43,7 +43,7 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/image-alt?application=axeAPI[39m"
+[34mhttps://dequeuniversity.com/rules/axe/3.4/image-alt?application=axeAPI[39m"
 `;
 
 exports[`React renders with enzyme wrapper correctly 1`] = `
@@ -66,5 +66,5 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/image-alt?application=axeAPI[39m"
+[34mhttps://dequeuniversity.com/rules/axe/3.4/image-alt?application=axeAPI[39m"
 `;

--- a/__tests__/__snapshots__/vuejs.test.js.snap
+++ b/__tests__/__snapshots__/vuejs.test.js.snap
@@ -20,7 +20,7 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/image-alt?application=axeAPI[39m"
+[34mhttps://dequeuniversity.com/rules/axe/3.4/image-alt?application=axeAPI[39m"
 `;
 
 exports[`Vue renders correctly 1`] = `
@@ -43,5 +43,5 @@ Received:
 [33m  Element's default semantics were not overridden with role=\\"none\\"[39m
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/3.3/image-alt?application=axeAPI[39m"
+[34mhttps://dequeuniversity.com/rules/axe/3.4/image-alt?application=axeAPI[39m"
 `;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 8.0.0"
   },
   "dependencies": {
-    "axe-core": "3.3.1",
+    "axe-core": "3.4.0",
     "chalk": "2.4.2",
     "jest-matcher-utils": "24.8.0",
     "lodash.merge": "4.6.2"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 8.0.0"
   },
   "dependencies": {
-    "axe-core": "3.4.0",
+    "axe-core": "3.4.1",
     "chalk": "2.4.2",
     "jest-matcher-utils": "24.8.0",
     "lodash.merge": "4.6.2"


### PR DESCRIPTION
axe-core 3.3.1 was released on Jul 24. There has been several bugfixes and features (90+ commits) since. Updating to the latest release of [3.4.1](https://github.com/dequelabs/axe-core/releases/tag/v3.4.1).

* Update package.json 
* Update jest snapshots to reflect changes in axe help URLs from 3.3 to 3.4