### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ it('should demonstrate this matcher`s usage', async () => {
 ![Screenshot of the resulting output from the usage example](example-cli.png)
 
 > Note, you can also require `'jest-axe/extend-expect'` which will call `expect.extend` for you.
-> This is especially helpful when using the jest `setupTestFrameworkScriptFile` configuration.
+> This is especially helpful when using the jest `setupFilesAfterEnv` configuration.
 
 ### Testing React
 


### PR DESCRIPTION
Since Jest 24.x setupTestFrameworkScriptFile is deprecated in favor of setupFilesAfterEnv.