### PR TITLE
Require Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - lts/carbon
   - lts/dubnium
+  - lts/erbium
   - stable

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Nick Colley",
   "license": "MIT",
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "dependencies": {
     "axe-core": "^3.5.1",


### PR DESCRIPTION
Our dependencies have updated and 10 is the earliest LTS release.