### PR TITLE
Remove 'cleanup()' from examples now that it is built in to @testing-library/* by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ it('should demonstrate this matcher`s usage with enzyme', async () => {
 const React = require('react')
 const App = require('./app')
 
-const { render, cleanup } = require('@testing-library/react')
+const { render } = require('@testing-library/react')
 const { axe, toHaveNoViolations } = require('jest-axe')
 expect.extend(toHaveNoViolations)
 
@@ -99,12 +99,10 @@ it('should demonstrate this matcher`s usage with react testing library', async (
   const results = await axe(container)
   
   expect(results).toHaveNoViolations()
-  
-  cleanup()
 })
 ```
 
-> Note: If you're using `react testing library` you should be using the
+> Note: If you're using `react testing library` <9.0.0 you should be using the
 > [`cleanup`](https://testing-library.com/docs/react-testing-library/api#cleanup) method. This method removes the rendered application from the DOM and ensures a clean HTML Document for further testing.
 
 ### Testing Vue with [Vue Test Utils](https://vue-test-utils.vuejs.org/)
@@ -130,7 +128,7 @@ it('should demonstrate this matcher`s usage with vue test utils', async () => {
 const React = require('react')
 const App = require('./app')
 
-const { render, cleanup } = require('@testing-library/vue')
+const { render } = require('@testing-library/vue')
 const { axe, toHaveNoViolations } = require('jest-axe')
 expect.extend(toHaveNoViolations)
 
@@ -139,11 +137,9 @@ it('should demonstrate this matcher`s usage with react testing library', async (
   const results = await axe(container)
   
   expect(results).toHaveNoViolations()
-  
-  cleanup()
 })
 ```
-> Note: If you're using `vue testing library` you should be using the
+> Note: If you're using `vue testing library` <3.0.0 you should be using the
 > [`cleanup`](https://testing-library.com/docs/vue-testing-library/api#cleanup) method. This method removes the rendered application from the DOM and ensures a clean HTML Document for further testing.
 
 ### Axe configuration

--- a/__tests__/reactjs.test.js
+++ b/__tests__/reactjs.test.js
@@ -18,7 +18,7 @@ describe('React', () => {
   })
 
   test('renders a react testing library container correctly', async () => {
-    const { render, cleanup } = require('@testing-library/react')
+    const { render } = require('@testing-library/react')
 
     const element = React.createElement('img', { src: '#' })
     const { container } = render(element)
@@ -27,20 +27,16 @@ describe('React', () => {
     expect(() => {
       expect(results).toHaveNoViolations()
     }).toThrowErrorMatchingSnapshot()
-
-    cleanup()
   })
 
   test('renders a react testing library container without duplicate ids', async () => {
-    const { render, cleanup } = require('@testing-library/react')
+    const { render } = require('@testing-library/react')
 
     const element = React.createElement('img', { src: '#', alt: 'test', id: 'test' })
     const { container } = render(element)
     const results = await axe(container)
 
     expect(results).toHaveNoViolations()
-    
-    cleanup()
   })
 
   test('renders with enzyme wrapper correctly', async () => {

--- a/__tests__/vuejs.test.js
+++ b/__tests__/vuejs.test.js
@@ -19,15 +19,13 @@ describe('Vue', () => {
   })
 
   it('renders a vue testing library container correctly', async () => {
-    const { render, cleanup } = require('@testing-library/vue')
+    const { render } = require('@testing-library/vue')
     const { container } = render(Image)
     const results = await axe(container)
     
     expect(() => {
       expect(results).toHaveNoViolations()
     }).toThrowErrorMatchingSnapshot()
-
-    cleanup()
   })
 
 })

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
-    "@testing-library/react": "^10.0.4",
-    "@testing-library/vue": "^5.0.3",
+    "@testing-library/react": "^10.2.1",
+    "@testing-library/vue": "^5.0.4",
     "@vue/server-test-utils": "^1.0.0-beta.31",
     "@vue/test-utils": "^1.0.0-beta.31",
     "enzyme": "^3.11.0",


### PR DESCRIPTION
The `cleanup()` method now does not have to be called manually when using `@testing-library/*`.  As this has now not been required for at 2 major versions we can remove it from the default examples, but, for now, leave a note for out of date consumers.

This was removed in:
- `/react`: https://github.com/testing-library/react-testing-library/releases/tag/v9.0.0 (latest is 10)
- `/vue`: https://github.com/testing-library/vue-testing-library/releases/tag/v3.0.0 (latest is 5)

What do you think @nickcolley?