### PR TITLE
Update axe-core to 3.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 10.0.0"
   },
   "dependencies": {
-    "axe-core": "^3.5.4",
+    "axe-core": "^3.5.5",
     "chalk": "^4.0.0",
     "jest-matcher-utils": "^26.0.1",
     "lodash.merge": "^4.6.2"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 10.0.0"
   },
   "dependencies": {
-    "axe-core": "^3.5.1",
+    "axe-core": "^3.5.4",
     "chalk": "^4.0.0",
     "jest-matcher-utils": "^26.0.1",
     "lodash.merge": "^4.6.2"


### PR DESCRIPTION
`axe-core` has released some patch version bug fixes we can take advantage of :) 

As these are patch versions the 'help' link captured in snapshots remains the same, so continue to pass.

https://github.com/dequelabs/axe-core/releases