### PR TITLE
Add a globalOptions configuration property to setup custom rules and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ it('should demonstrate this matcher`s usage with a default config', async () => 
 })
 ```
 
+### Setting custom rules and checks.
+
+The configuration object passed to `configureAxe` accepts a `globalOptions` property to configure the format of the data used by axe and to add custom checks and rules. The property value is the same as the parameter passed to [axe.configure](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#parameters-1). 
+
+Refer to [Developing Axe-core Rules](https://github.com/dequelabs/axe-core/blob/master/doc/rule-development.md) for instructions on how to develop custom rules and checks.
+
 ## Thanks
 - [Jest][Jest] for the great test runner that allows extending matchers.
 - [aXe](https://www.deque.com/axe/) for the wonderful axe-core that makes it so easy to do this.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,21 @@ it('should demonstrate this matcher`s usage with a default config', async () => 
 
 ### Setting custom rules and checks.
 
-The configuration object passed to `configureAxe` accepts a `globalOptions` property to configure the format of the data used by axe and to add custom checks and rules. The property value is the same as the parameter passed to [axe.configure](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#parameters-1). 
+The configuration object passed to `configureAxe`, accepts a `globalOptions` property to configure the format of the data used by axe and to add custom checks and rules. The property value is the same as the parameter passed to [axe.configure](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#parameters-1). 
+
+```javascript
+// Global helper file (axe-helper.js)
+const { configureAxe } = require('jest-axe')
+
+const axe = configureAxe({
+  globalOptions: {
+    checks: [/* custom checks definitions */]
+  },
+  // ...
+})
+
+module.exports = axe
+```
 
 Refer to [Developing Axe-core Rules](https://github.com/dequelabs/axe-core/blob/master/doc/rule-development.md) for instructions on how to develop custom rules and checks.
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -334,5 +334,61 @@ describe('jest-axe', () => {
         expect(await axe(html)).toHaveNoViolations()
       })
     })
+    describe('configure custom rule', () => {
+      
+      expect.extend(toHaveNoViolations)
+
+      it('should report custom rules', async () => {
+
+        const check = {
+          id: 'demo-has-data',
+          evaluate(node) {
+            return node.hasAttribute('data-demo-rule');
+            
+          },
+          metadata: {
+            impact: 'serious',
+            messages: {
+              fail: 'Error!',
+            },
+          },
+        }
+        const rule = {
+          id: 'demo-rule',
+          selector: '.demo',
+          enabled: false,
+          tags: ['demo-rules'],
+          any: ['demo-has-data'],
+          metadata: {
+            description: 'Demo check',
+            help: 'Demo check',
+          },
+        }
+
+        const configuredAxe = configureAxe({
+          globalOptions: {
+            rules: [rule],
+            checks: [check]
+          },
+          rules: {
+            'demo-rule': { enabled: true }
+          }
+        })
+
+
+        const html = `
+        <html>
+          <body>
+            <main>
+              <div class="demo">
+            </main>
+          </body>
+        </html>
+        `
+
+        const results = await configuredAxe(html)
+        expect(results.violations[0].id).toBe('demo-rule')
+      })
+    })
   })
 })

--- a/index.js
+++ b/index.js
@@ -38,10 +38,21 @@ function mount (html) {
 /**
  * Small wrapper for axe-core#run that enables promises (required for Jest),
  * default options and injects html to be tested
- * @param {object} [defaultOptions] default options to use in all instances
+ * @param {object} [options] default options to use in all instances
+ * @param {object} [options.globalOptions] Global axe-core configuration (See https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure)
+ * @param {object} [options.*] Any other property will be passed as the runner configuration (See https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter)
  * @returns {function} returns instance of axe
  */
-function configureAxe (defaultOptions = {}) {
+function configureAxe (options = {}) {
+
+  const { globalOptions = {}, ...runnerOptions } = options
+
+  // Set the global configuration for
+  // axe-core 
+  // https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure 
+  axeCore.configure(globalOptions)
+
+
   /**
    * Small wrapper for axe-core#run that enables promises (required for Jest),
    * default options and injects html to be tested
@@ -51,7 +62,7 @@ function configureAxe (defaultOptions = {}) {
    */
   return function axe (html, additionalOptions = {}) {
     const [element, restore] = mount(html)
-    const options = merge({}, defaultOptions, additionalOptions)
+    const options = merge({}, runnerOptions, additionalOptions)
 
     return new Promise((resolve, reject) => {
       axeCore.run(element, options, (err, results) => {
@@ -116,9 +127,12 @@ const toHaveNoViolations = {
             printReceived(`${violation.help} (${violation.id})`) +
             lineBreak +
             chalk.yellow(node.failureSummary) +
-            lineBreak +
-            `You can find more information on this issue here: \n` +
-            chalk.blue(violation.helpUrl)
+            lineBreak + (
+              violation.helpUrl ? 
+              `You can find more information on this issue here: \n${chalk.blue(violation.helpUrl)}` : 
+              ''
+            )
+            
           )
         }).join(lineBreak)
 


### PR DESCRIPTION
This PR adds the ability to use the `configureAxe` function to setup custom checks and rules by adding a `globalOptions` property whose value will be passed to `axe.configure`.

It also updates the report log by checking for `helpUrl` before outputting the relative lines because custom rules might not have a help URL.

Reference: #112 

@nickcolley If you think this solution is fine, I will submit a PR to update the TypeScript definition as well.