### PR TITLE
Update Testing React section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,17 @@ it('should demonstrate this matcher`s usage', async () => {
 ### Testing React
 
 ```javascript
-const React = require('react')
-const { render } =  require('react-dom')
-const App = require('./app')
-
-const { axe, toHaveNoViolations } = require('jest-axe')
+import React from 'react';
+import { render } from 'react-dom'
+import EventsPage from '../pages/EventsPage';
+ 
+import { axe, toHaveNoViolations } from 'jest-axe';
 expect.extend(toHaveNoViolations)
 
 it('should demonstrate this matcher`s usage with react', async () => {
-  render(<App/>, document.body)
-  const results = await axe(document.body)
+  const root = document.createElement("div");
+  render(<App/>, root)
+  const results = await axe(root)
   expect(results).toHaveNoViolations()
 })
 ```


### PR DESCRIPTION
The previous way was throwing this error
```
Uncaught Error: Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function but got: object
```
Ought to update to imports, also when running the test if we pass document.body inside rendering we get this error
```
 Warning: render(): Rendering components directly into document.body is discouraged, since its children are often manipulated by third-party scripts and browser extensions. This may lead to subtle reconciliation issues. Try rendering into a container element created for your app.
```