### PR TITLE
don't capitalize the "x" in "axe"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![Repository CI Status](https://github.com/nickcolley/jest-axe/workflows/test/badge.svg)](https://github.com/nickcolley/jest-axe/actions?query=workflow%3Atest)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
-Custom [Jest][Jest] matcher for [aXe](https://github.com/dequelabs/axe-core) for testing accessibility
+Custom [Jest][Jest] matcher for [axe](https://github.com/dequelabs/axe-core) for testing accessibility
 
 ## ⚠️✋ This project does not guarantee what you build is accessible.
 The GDS Accessibility team found that only [~30% of issues are found by automated testing](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage).
 
-Tools like aXe are similar to [code linters](https://en.wikipedia.org/wiki/Lint_%28software%29) such as [eslint](https://eslint.org/) or [stylelint](https://stylelint.io/): they can find common issues but cannot guarantee what you build works for users.
+Tools like axe are similar to [code linters](https://en.wikipedia.org/wiki/Lint_%28software%29) such as [eslint](https://eslint.org/) or [stylelint](https://stylelint.io/): they can find common issues but cannot guarantee what you build works for users.
 
 You'll also need to:
 - test your interface with the [assistive technologies that real users use](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#when-to-test) (see also [WebAIM's survey results](https://webaim.org/projects/screenreadersurvey8/#primary)).
@@ -263,7 +263,7 @@ Refer to [Developing Axe-core Rules](https://github.com/dequelabs/axe-core/blob/
 
 ## Thanks
 - [Jest][Jest] for the great test runner that allows extending matchers.
-- [aXe](https://www.deque.com/axe/) for the wonderful axe-core that makes it so easy to do this.
+- [axe](https://www.deque.com/axe/) for the wonderful axe-core that makes it so easy to do this.
 - Government Digital Service for making coding in the open the default.
   - GOV.UK Publishing Frontend team who published the [basis of the aXe reporter](https://github.com/alphagov/govuk_publishing_components/blob/581c22c9d35d85d5d985571d007f6397a4399f4c/spec/javascripts/govuk_publishing_components/AccessibilityTestSpec.js)
 - [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot) for inspiration on README and repo setup


### PR DESCRIPTION
This patch updates the README, replacing `aXe` with `axe`. [We stopped doing this awhile back](https://github.com/dequelabs/axe-core/pull/1495).