### PR TITLE
feat: bump axe core to 4.2.1 and fix unit test's failures

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -15,12 +15,11 @@ Fix any of the following:
   Element does not have an alt attribute
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute or the title attribute is empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
+  Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/image-alt?application=axeAPI
 
 ────────
 
@@ -30,13 +29,13 @@ Expected the HTML found at $('img') to have no violations:
 
 Received:
 
-\\"All page content must be contained by landmarks (region)\\"
+\\"All page content should be contained by landmarks (region)\\"
 
 Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/region?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.2/region?application=axeAPI"
 `;
 
 exports[`jest-axe toHaveNoViolations returns correctly formatted message when violations are present 1`] = `
@@ -77,12 +76,11 @@ Fix any of the following:
   Element does not have an alt attribute
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute or the title attribute is empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
+  Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/image-alt?application=axeAPI
 
 Expected the HTML found at $('img[src=\\"http\\\\:\\\\/\\\\/example\\\\.com\\\\/2\\"]') to have no violations:
 
@@ -96,12 +94,11 @@ Fix any of the following:
   Element does not have an alt attribute
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute or the title attribute is empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
+  Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/image-alt?application=axeAPI
 
 ────────
 
@@ -114,14 +111,16 @@ Received:
 \\"Form elements must have labels (label)\\"
 
 Fix any of the following:
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
   Form element does not have an implicit (wrapped) <label>
   Form element does not have an explicit <label>
-  Element has no title attribute or the title attribute is empty
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
+  Element has no placeholder attribute
+  Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/label?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/label?application=axeAPI
 
 ────────
 
@@ -140,11 +139,10 @@ Fix any of the following:
   Element does not have text that is visible to screen readers
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/link-name?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/link-name?application=axeAPI
 
 Expected the HTML found at $('a[href$=\\"\\\\#link-name-2\\"]') to have no violations:
 
@@ -161,11 +159,10 @@ Fix any of the following:
   Element does not have text that is visible to screen readers
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/link-name?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/link-name?application=axeAPI
 
 ────────
 
@@ -175,13 +172,13 @@ Expected the HTML found at $('img[src$=\\"example\\\\.com\\"]') to have no viola
 
 Received:
 
-\\"All page content must be contained by landmarks (region)\\"
+\\"All page content should be contained by landmarks (region)\\"
 
 Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/region?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/region?application=axeAPI
 
 Expected the HTML found at $('img[src=\\"http\\\\:\\\\/\\\\/example\\\\.com\\\\/2\\"]') to have no violations:
 
@@ -189,13 +186,13 @@ Expected the HTML found at $('img[src=\\"http\\\\:\\\\/\\\\/example\\\\.com\\\\/
 
 Received:
 
-\\"All page content must be contained by landmarks (region)\\"
+\\"All page content should be contained by landmarks (region)\\"
 
 Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/region?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/region?application=axeAPI
 
 Expected the HTML found at $('input') to have no violations:
 
@@ -203,11 +200,11 @@ Expected the HTML found at $('input') to have no violations:
 
 Received:
 
-\\"All page content must be contained by landmarks (region)\\"
+\\"All page content should be contained by landmarks (region)\\"
 
 Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/region?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.2/region?application=axeAPI"
 `;

--- a/__tests__/__snapshots__/reactjs.test.js.snap
+++ b/__tests__/__snapshots__/reactjs.test.js.snap
@@ -15,12 +15,11 @@ Fix any of the following:
   Element does not have an alt attribute
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute or the title attribute is empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
+  Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.2/image-alt?application=axeAPI"
 `;
 
 exports[`React renders correctly 1`] = `
@@ -38,12 +37,11 @@ Fix any of the following:
   Element does not have an alt attribute
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute or the title attribute is empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
+  Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/image-alt?application=axeAPI
 
 ────────
 
@@ -53,13 +51,13 @@ Expected the HTML found at $('img') to have no violations:
 
 Received:
 
-\\"All page content must be contained by landmarks (region)\\"
+\\"All page content should be contained by landmarks (region)\\"
 
 Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/region?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.2/region?application=axeAPI"
 `;
 
 exports[`React renders with enzyme wrapper correctly 1`] = `
@@ -77,12 +75,11 @@ Fix any of the following:
   Element does not have an alt attribute
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute or the title attribute is empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
+  Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/image-alt?application=axeAPI
 
 ────────
 
@@ -92,11 +89,11 @@ Expected the HTML found at $('img') to have no violations:
 
 Received:
 
-\\"All page content must be contained by landmarks (region)\\"
+\\"All page content should be contained by landmarks (region)\\"
 
 Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/region?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.2/region?application=axeAPI"
 `;

--- a/__tests__/__snapshots__/vuejs.test.js.snap
+++ b/__tests__/__snapshots__/vuejs.test.js.snap
@@ -15,12 +15,11 @@ Fix any of the following:
   Element does not have an alt attribute
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute or the title attribute is empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
+  Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.2/image-alt?application=axeAPI"
 `;
 
 exports[`Vue renders correctly 1`] = `
@@ -38,12 +37,11 @@ Fix any of the following:
   Element does not have an alt attribute
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute or the title attribute is empty
-  Element's default semantics were not overridden with role=\\"presentation\\"
-  Element's default semantics were not overridden with role=\\"none\\"
+  Element has no title attribute
+  Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.2/image-alt?application=axeAPI
 
 ────────
 
@@ -53,11 +51,11 @@ Expected the HTML found at $('#test-image') to have no violations:
 
 Received:
 
-\\"All page content must be contained by landmarks (region)\\"
+\\"All page content should be contained by landmarks (region)\\"
 
 Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.0/region?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.2/region?application=axeAPI"
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,9 +1278,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.1.tgz",
-      "integrity": "sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw=="
+      "version": "4.2.1",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/axe-core/-/axe-core-4.2.1.tgz",
+      "integrity": "sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA=="
     },
     "babel-jest": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 10.0.0"
   },
   "dependencies": {
-    "axe-core": "4.0.1",
+    "axe-core": "^4.2.1",
     "chalk": "4.1.0",
     "jest-matcher-utils": "26.6.1",
     "lodash.merge": "4.6.2"


### PR DESCRIPTION
Summary
- bumped axe core to 4.2.1 
- updated snapshots

4.2.1 version has greatly improved vs 4.0.1 with major fixes and greater coverge.

I would like to start using it in our team but the old version 4.0. 1is showing false negative issues for 'button-name' and 'svg-img-alt' rules that were fixed in 4.2.1.

I would really appreciate it if this change gets merged.
