### PR TITLE
Disable axe color contrast checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,10 @@ module.exports = axe
 
 Refer to [Developing Axe-core Rules](https://github.com/dequelabs/axe-core/blob/master/doc/rule-development.md) for instructions on how to develop custom rules and checks.
 
+## Checks that do not work in jest-axe
+
+Color contrast checks do not work in JSDOM so are turned off in jest-axe. 
+
 ## Thanks
 - [Jest][Jest] for the great test runner that allows extending matchers.
 - [axe](https://www.deque.com/axe/) for the wonderful axe-core that makes it so easy to do this.

--- a/index.js
+++ b/index.js
@@ -47,11 +47,20 @@ function configureAxe (options = {}) {
 
   const { globalOptions = {}, ...runnerOptions } = options
 
-  // Set the global configuration for
-  // axe-core 
+  // Set the global configuration for axe-core 
   // https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure 
-  axeCore.configure(globalOptions)
-
+  const { checks = [], ...otherGlobalOptions } = globalOptions
+  axeCore.configure({
+    checks: [
+      {
+        // color contrast checking doesnt work in a jsdom environment.
+        id: 'color-contrast',
+        enabled: false
+      },
+      ...checks
+    ],
+    ...otherGlobalOptions
+  })
 
   /**
    * Small wrapper for axe-core#run that enables promises (required for Jest),


### PR DESCRIPTION
These checks require a real browser environment and fail in jsdom.

Closes #147