### PR TITLE
Update axe-core to latest

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -1,210 +1,210 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-axe readme first readme example should demonstrate this matcher\`s usage 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
+"expect(received).toHaveNoViolations(expected)
 
 Expected the HTML found at $('img') to have no violations:
 
-[90m<img src="#">[39m
+<img src="#">
 
 Received:
 
-[31m"Images must have alternate text (image-alt)"[39m
+"Images must have alternate text (image-alt)"
 
-[33mFix any of the following:[39m
-[33m  Element does not have an alt attribute[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
-[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
+Fix any of the following:
+  Element does not have an alt attribute
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
+  Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
 
 ────────
 
 Expected the HTML found at $('img') to have no violations:
 
-[90m<img src="#">[39m
+<img src="#">
 
 Received:
 
-[31m"All page content should be contained by landmarks (region)"[39m
+"All page content should be contained by landmarks (region)"
 
-[33mFix any of the following:[39m
-[33m  Some page content is not contained by landmarks[39m
+Fix any of the following:
+  Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m"
+https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI"
 `;
 
 exports[`jest-axe toHaveNoViolations returns correctly formatted message when violations are present 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
+"expect(received).toHaveNoViolations(expected)
 
 Expected the HTML found at $('body > img') to have no violations:
 
-[90m<img src="">[39m
+<img src="">
 
 Received:
 
-[31m"Images must have alternate text (image-alt)"[39m
+"Images must have alternate text (image-alt)"
 
-[33mFix any of the following:[39m
-[33m  Element does not have an alt attribute[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty or not visible[39m
-[33m  Element has no title attribute or the title attribute is empty[39m
-[33m  Element's default semantics were not overridden with role="presentation"[39m
-[33m  Element's default semantics were not overridden with role="none"[39m
+Fix any of the following:
+  Element does not have an alt attribute
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty or not visible
+  Element has no title attribute or the title attribute is empty
+  Element's default semantics were not overridden with role="presentation"
+  Element's default semantics were not overridden with role="none"
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/2.6/image-alt?application=axeAPI[39m"
+https://dequeuniversity.com/rules/axe/2.6/image-alt?application=axeAPI"
 `;
 
 exports[`jest-axe toHaveNoViolations returns properly formatted text with more complex example 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
+"expect(received).toHaveNoViolations(expected)
 
 Expected the HTML found at $('img[src$="example.com"]') to have no violations:
 
-[90m<img src="http://example.com">[39m
+<img src="http://example.com">
 
 Received:
 
-[31m"Images must have alternate text (image-alt)"[39m
+"Images must have alternate text (image-alt)"
 
-[33mFix any of the following:[39m
-[33m  Element does not have an alt attribute[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
-[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
+Fix any of the following:
+  Element does not have an alt attribute
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
+  Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
 
 Expected the HTML found at $('img[src="http://example.com/2"]') to have no violations:
 
-[90m<img src="http://example.com/2">[39m
+<img src="http://example.com/2">
 
 Received:
 
-[31m"Images must have alternate text (image-alt)"[39m
+"Images must have alternate text (image-alt)"
 
-[33mFix any of the following:[39m
-[33m  Element does not have an alt attribute[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
-[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
+Fix any of the following:
+  Element does not have an alt attribute
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
+  Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
 
 ────────
 
 Expected the HTML found at $('input') to have no violations:
 
-[90m<input type="text">[39m
+<input type="text">
 
 Received:
 
-[31m"Form elements must have labels (label)"[39m
+"Form elements must have labels (label)"
 
-[33mFix any of the following:[39m
-[33m  Form element does not have an implicit (wrapped) <label>[39m
-[33m  Form element does not have an explicit <label>[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
-[33m  Element has no placeholder attribute[39m
-[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
+Fix any of the following:
+  Form element does not have an implicit (wrapped) <label>
+  Form element does not have an explicit <label>
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
+  Element has no placeholder attribute
+  Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/label?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/label?application=axeAPI
 
 ────────
 
 Expected the HTML found at $('a[href$="#link-name"]') to have no violations:
 
-[90m<a href="#link-name"></a>[39m
+<a href="#link-name"></a>
 
 Received:
 
-[31m"Links must have discernible text (link-name)"[39m
+"Links must have discernible text (link-name)"
 
-[33mFix all of the following:[39m
-[33m  Element is in tab order and does not have accessible text[39m
-[33m[39m
-[33mFix any of the following:[39m
-[33m  Element does not have text that is visible to screen readers[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
+Fix all of the following:
+  Element is in tab order and does not have accessible text
+
+Fix any of the following:
+  Element does not have text that is visible to screen readers
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/link-name?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/link-name?application=axeAPI
 
 Expected the HTML found at $('a[href$="#link-name-2"]') to have no violations:
 
-[90m<a href="#link-name-2"></a>[39m
+<a href="#link-name-2"></a>
 
 Received:
 
-[31m"Links must have discernible text (link-name)"[39m
+"Links must have discernible text (link-name)"
 
-[33mFix all of the following:[39m
-[33m  Element is in tab order and does not have accessible text[39m
-[33m[39m
-[33mFix any of the following:[39m
-[33m  Element does not have text that is visible to screen readers[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
+Fix all of the following:
+  Element is in tab order and does not have accessible text
+
+Fix any of the following:
+  Element does not have text that is visible to screen readers
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/link-name?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/link-name?application=axeAPI
 
 ────────
 
 Expected the HTML found at $('img[src$="example.com"]') to have no violations:
 
-[90m<img src="http://example.com">[39m
+<img src="http://example.com">
 
 Received:
 
-[31m"All page content should be contained by landmarks (region)"[39m
+"All page content should be contained by landmarks (region)"
 
-[33mFix any of the following:[39m
-[33m  Some page content is not contained by landmarks[39m
+Fix any of the following:
+  Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI
 
 Expected the HTML found at $('img[src="http://example.com/2"]') to have no violations:
 
-[90m<img src="http://example.com/2">[39m
+<img src="http://example.com/2">
 
 Received:
 
-[31m"All page content should be contained by landmarks (region)"[39m
+"All page content should be contained by landmarks (region)"
 
-[33mFix any of the following:[39m
-[33m  Some page content is not contained by landmarks[39m
+Fix any of the following:
+  Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI
 
 Expected the HTML found at $('input') to have no violations:
 
-[90m<input type="text">[39m
+<input type="text">
 
 Received:
 
-[31m"All page content should be contained by landmarks (region)"[39m
+"All page content should be contained by landmarks (region)"
 
-[33mFix any of the following:[39m
-[33m  Some page content is not contained by landmarks[39m
+Fix any of the following:
+  Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m"
+https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI"
 `;

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -1,210 +1,210 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-axe readme first readme example should demonstrate this matcher\`s usage 1`] = `
-"expect(received).toHaveNoViolations(expected)
+"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
 
 Expected the HTML found at $('img') to have no violations:
 
-<img src="#">
+[90m<img src="#">[39m
 
 Received:
 
-"Images must have alternate text (image-alt)"
+[31m"Images must have alternate text (image-alt)"[39m
 
-Fix any of the following:
-  Element does not have an alt attribute
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
-  Element's default semantics were not overridden with role="none" or role="presentation"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
+[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/image-alt?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
 
 ────────
 
 Expected the HTML found at $('img') to have no violations:
 
-<img src="#">
+[90m<img src="#">[39m
 
 Received:
 
-"All page content should be contained by landmarks (region)"
+[31m"All page content should be contained by landmarks (region)"[39m
 
-Fix any of the following:
-  Some page content is not contained by landmarks
+[33mFix any of the following:[39m
+[33m  Some page content is not contained by landmarks[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/region?application=axeAPI"
+[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m"
 `;
 
 exports[`jest-axe toHaveNoViolations returns correctly formatted message when violations are present 1`] = `
-"expect(received).toHaveNoViolations(expected)
+"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
 
 Expected the HTML found at $('body > img') to have no violations:
 
-<img src="">
+[90m<img src="">[39m
 
 Received:
 
-"Images must have alternate text (image-alt)"
+[31m"Images must have alternate text (image-alt)"[39m
 
-Fix any of the following:
-  Element does not have an alt attribute
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty or not visible
-  Element has no title attribute or the title attribute is empty
-  Element's default semantics were not overridden with role="presentation"
-  Element's default semantics were not overridden with role="none"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty or not visible[39m
+[33m  Element has no title attribute or the title attribute is empty[39m
+[33m  Element's default semantics were not overridden with role="presentation"[39m
+[33m  Element's default semantics were not overridden with role="none"[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/2.6/image-alt?application=axeAPI"
+[34mhttps://dequeuniversity.com/rules/axe/2.6/image-alt?application=axeAPI[39m"
 `;
 
 exports[`jest-axe toHaveNoViolations returns properly formatted text with more complex example 1`] = `
-"expect(received).toHaveNoViolations(expected)
+"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
 
 Expected the HTML found at $('img[src$="example.com"]') to have no violations:
 
-<img src="http://example.com">
+[90m<img src="http://example.com">[39m
 
 Received:
 
-"Images must have alternate text (image-alt)"
+[31m"Images must have alternate text (image-alt)"[39m
 
-Fix any of the following:
-  Element does not have an alt attribute
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
-  Element's default semantics were not overridden with role="none" or role="presentation"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
+[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/image-alt?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
 
 Expected the HTML found at $('img[src="http://example.com/2"]') to have no violations:
 
-<img src="http://example.com/2">
+[90m<img src="http://example.com/2">[39m
 
 Received:
 
-"Images must have alternate text (image-alt)"
+[31m"Images must have alternate text (image-alt)"[39m
 
-Fix any of the following:
-  Element does not have an alt attribute
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
-  Element's default semantics were not overridden with role="none" or role="presentation"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
+[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/image-alt?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
 
 ────────
 
 Expected the HTML found at $('input') to have no violations:
 
-<input type="text">
+[90m<input type="text">[39m
 
 Received:
 
-"Form elements must have labels (label)"
+[31m"Form elements must have labels (label)"[39m
 
-Fix any of the following:
-  Form element does not have an implicit (wrapped) <label>
-  Form element does not have an explicit <label>
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
-  Element has no placeholder attribute
-  Element's default semantics were not overridden with role="none" or role="presentation"
+[33mFix any of the following:[39m
+[33m  Form element does not have an implicit (wrapped) <label>[39m
+[33m  Form element does not have an explicit <label>[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
+[33m  Element has no placeholder attribute[39m
+[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/label?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/label?application=axeAPI[39m
 
 ────────
 
 Expected the HTML found at $('a[href$="#link-name"]') to have no violations:
 
-<a href="#link-name"></a>
+[90m<a href="#link-name"></a>[39m
 
 Received:
 
-"Links must have discernible text (link-name)"
+[31m"Links must have discernible text (link-name)"[39m
 
-Fix all of the following:
-  Element is in tab order and does not have accessible text
-
-Fix any of the following:
-  Element does not have text that is visible to screen readers
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
+[33mFix all of the following:[39m
+[33m  Element is in tab order and does not have accessible text[39m
+[33m[39m
+[33mFix any of the following:[39m
+[33m  Element does not have text that is visible to screen readers[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/link-name?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/link-name?application=axeAPI[39m
 
 Expected the HTML found at $('a[href$="#link-name-2"]') to have no violations:
 
-<a href="#link-name-2"></a>
+[90m<a href="#link-name-2"></a>[39m
 
 Received:
 
-"Links must have discernible text (link-name)"
+[31m"Links must have discernible text (link-name)"[39m
 
-Fix all of the following:
-  Element is in tab order and does not have accessible text
-
-Fix any of the following:
-  Element does not have text that is visible to screen readers
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
+[33mFix all of the following:[39m
+[33m  Element is in tab order and does not have accessible text[39m
+[33m[39m
+[33mFix any of the following:[39m
+[33m  Element does not have text that is visible to screen readers[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/link-name?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/link-name?application=axeAPI[39m
 
 ────────
 
 Expected the HTML found at $('img[src$="example.com"]') to have no violations:
 
-<img src="http://example.com">
+[90m<img src="http://example.com">[39m
 
 Received:
 
-"All page content should be contained by landmarks (region)"
+[31m"All page content should be contained by landmarks (region)"[39m
 
-Fix any of the following:
-  Some page content is not contained by landmarks
+[33mFix any of the following:[39m
+[33m  Some page content is not contained by landmarks[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/region?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m
 
 Expected the HTML found at $('img[src="http://example.com/2"]') to have no violations:
 
-<img src="http://example.com/2">
+[90m<img src="http://example.com/2">[39m
 
 Received:
 
-"All page content should be contained by landmarks (region)"
+[31m"All page content should be contained by landmarks (region)"[39m
 
-Fix any of the following:
-  Some page content is not contained by landmarks
+[33mFix any of the following:[39m
+[33m  Some page content is not contained by landmarks[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/region?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m
 
 Expected the HTML found at $('input') to have no violations:
 
-<input type="text">
+[90m<input type="text">[39m
 
 Received:
 
-"All page content should be contained by landmarks (region)"
+[31m"All page content should be contained by landmarks (region)"[39m
 
-Fix any of the following:
-  Some page content is not contained by landmarks
+[33mFix any of the following:[39m
+[33m  Some page content is not contained by landmarks[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/region?application=axeAPI"
+[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m"
 `;

--- a/__tests__/__snapshots__/reactjs.test.js.snap
+++ b/__tests__/__snapshots__/reactjs.test.js.snap
@@ -1,61 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`React renders a react testing library container correctly 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
+"expect(received).toHaveNoViolations(expected)
 
 Expected the HTML found at $('img') to have no violations:
 
-[90m<img src="#">[39m
+<img src="#">
 
 Received:
 
-[31m"Images must have alternate text (image-alt)"[39m
+"Images must have alternate text (image-alt)"
 
-[33mFix any of the following:[39m
-[33m  Element does not have an alt attribute[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
-[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
+Fix any of the following:
+  Element does not have an alt attribute
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
+  Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m"
+https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI"
 `;
 
 exports[`React renders correctly 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
+"expect(received).toHaveNoViolations(expected)
 
 Expected the HTML found at $('img') to have no violations:
 
-[90m<img src="#">[39m
+<img src="#">
 
 Received:
 
-[31m"Images must have alternate text (image-alt)"[39m
+"Images must have alternate text (image-alt)"
 
-[33mFix any of the following:[39m
-[33m  Element does not have an alt attribute[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
-[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
+Fix any of the following:
+  Element does not have an alt attribute
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
+  Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
 
 ────────
 
 Expected the HTML found at $('img') to have no violations:
 
-[90m<img src="#">[39m
+<img src="#">
 
 Received:
 
-[31m"All page content should be contained by landmarks (region)"[39m
+"All page content should be contained by landmarks (region)"
 
-[33mFix any of the following:[39m
-[33m  Some page content is not contained by landmarks[39m
+Fix any of the following:
+  Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m"
+https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI"
 `;

--- a/__tests__/__snapshots__/reactjs.test.js.snap
+++ b/__tests__/__snapshots__/reactjs.test.js.snap
@@ -1,61 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`React renders a react testing library container correctly 1`] = `
-"expect(received).toHaveNoViolations(expected)
+"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
 
 Expected the HTML found at $('img') to have no violations:
 
-<img src="#">
+[90m<img src="#">[39m
 
 Received:
 
-"Images must have alternate text (image-alt)"
+[31m"Images must have alternate text (image-alt)"[39m
 
-Fix any of the following:
-  Element does not have an alt attribute
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
-  Element's default semantics were not overridden with role="none" or role="presentation"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
+[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/image-alt?application=axeAPI"
+[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m"
 `;
 
 exports[`React renders correctly 1`] = `
-"expect(received).toHaveNoViolations(expected)
+"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
 
 Expected the HTML found at $('img') to have no violations:
 
-<img src="#">
+[90m<img src="#">[39m
 
 Received:
 
-"Images must have alternate text (image-alt)"
+[31m"Images must have alternate text (image-alt)"[39m
 
-Fix any of the following:
-  Element does not have an alt attribute
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
-  Element's default semantics were not overridden with role="none" or role="presentation"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
+[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/image-alt?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
 
 ────────
 
 Expected the HTML found at $('img') to have no violations:
 
-<img src="#">
+[90m<img src="#">[39m
 
 Received:
 
-"All page content should be contained by landmarks (region)"
+[31m"All page content should be contained by landmarks (region)"[39m
 
-Fix any of the following:
-  Some page content is not contained by landmarks
+[33mFix any of the following:[39m
+[33m  Some page content is not contained by landmarks[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/region?application=axeAPI"
+[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m"
 `;

--- a/__tests__/__snapshots__/vuejs.test.js.snap
+++ b/__tests__/__snapshots__/vuejs.test.js.snap
@@ -1,61 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Vue renders a vue testing library container correctly 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
+"expect(received).toHaveNoViolations(expected)
 
 Expected the HTML found at $('#test-image') to have no violations:
 
-[90m<img id="test-image" src="#">[39m
+<img id="test-image" src="#">
 
 Received:
 
-[31m"Images must have alternate text (image-alt)"[39m
+"Images must have alternate text (image-alt)"
 
-[33mFix any of the following:[39m
-[33m  Element does not have an alt attribute[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
-[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
+Fix any of the following:
+  Element does not have an alt attribute
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
+  Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m"
+https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI"
 `;
 
 exports[`Vue renders correctly 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
+"expect(received).toHaveNoViolations(expected)
 
 Expected the HTML found at $('#test-image') to have no violations:
 
-[90m<img id="test-image" src="#">[39m
+<img id="test-image" src="#">
 
 Received:
 
-[31m"Images must have alternate text (image-alt)"[39m
+"Images must have alternate text (image-alt)"
 
-[33mFix any of the following:[39m
-[33m  Element does not have an alt attribute[39m
-[33m  aria-label attribute does not exist or is empty[39m
-[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
-[33m  Element has no title attribute[39m
-[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
+Fix any of the following:
+  Element does not have an alt attribute
+  aria-label attribute does not exist or is empty
+  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+  Element has no title attribute
+  Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
+https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
 
 ────────
 
 Expected the HTML found at $('#test-image') to have no violations:
 
-[90m<img id="test-image" src="#">[39m
+<img id="test-image" src="#">
 
 Received:
 
-[31m"All page content should be contained by landmarks (region)"[39m
+"All page content should be contained by landmarks (region)"
 
-[33mFix any of the following:[39m
-[33m  Some page content is not contained by landmarks[39m
+Fix any of the following:
+  Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m"
+https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI"
 `;

--- a/__tests__/__snapshots__/vuejs.test.js.snap
+++ b/__tests__/__snapshots__/vuejs.test.js.snap
@@ -1,61 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Vue renders a vue testing library container correctly 1`] = `
-"expect(received).toHaveNoViolations(expected)
+"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
 
 Expected the HTML found at $('#test-image') to have no violations:
 
-<img id="test-image" src="#">
+[90m<img id="test-image" src="#">[39m
 
 Received:
 
-"Images must have alternate text (image-alt)"
+[31m"Images must have alternate text (image-alt)"[39m
 
-Fix any of the following:
-  Element does not have an alt attribute
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
-  Element's default semantics were not overridden with role="none" or role="presentation"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
+[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/image-alt?application=axeAPI"
+[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m"
 `;
 
 exports[`Vue renders correctly 1`] = `
-"expect(received).toHaveNoViolations(expected)
+"[2mexpect([22m[31mreceived[39m[2m).toHaveNoViolations([22m[32mexpected[39m[2m)[22m
 
 Expected the HTML found at $('#test-image') to have no violations:
 
-<img id="test-image" src="#">
+[90m<img id="test-image" src="#">[39m
 
 Received:
 
-"Images must have alternate text (image-alt)"
+[31m"Images must have alternate text (image-alt)"[39m
 
-Fix any of the following:
-  Element does not have an alt attribute
-  aria-label attribute does not exist or is empty
-  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-  Element has no title attribute
-  Element's default semantics were not overridden with role="none" or role="presentation"
+[33mFix any of the following:[39m
+[33m  Element does not have an alt attribute[39m
+[33m  aria-label attribute does not exist or is empty[39m
+[33m  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty[39m
+[33m  Element has no title attribute[39m
+[33m  Element's default semantics were not overridden with role="none" or role="presentation"[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/image-alt?application=axeAPI
+[34mhttps://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI[39m
 
 ────────
 
 Expected the HTML found at $('#test-image') to have no violations:
 
-<img id="test-image" src="#">
+[90m<img id="test-image" src="#">[39m
 
 Received:
 
-"All page content should be contained by landmarks (region)"
+[31m"All page content should be contained by landmarks (region)"[39m
 
-Fix any of the following:
-  Some page content is not contained by landmarks
+[33mFix any of the following:[39m
+[33m  Some page content is not contained by landmarks[39m
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.5/region?application=axeAPI"
+[34mhttps://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI[39m"
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
-        "axe-core": "4.5.1",
+        "axe-core": "4.7.2",
         "chalk": "4.1.2",
         "jest-matcher-utils": "29.2.2",
         "lodash.merge": "4.6.2"
@@ -1853,9 +1853,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.1.tgz",
-      "integrity": "sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
+      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "engines": {
         "node": ">=4"
       }
@@ -6330,20 +6330,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -8006,8 +7992,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.2.1.tgz",
       "integrity": "sha512-AkLt24wnnxedJ3NX090JYiueog184QqlR5TVNZM+lggCrK8XjeuPr274okaLqDmiRgp4XVCaGa07KqKLGQbsMQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "abab": {
       "version": "2.0.6",
@@ -8035,8 +8020,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -8135,9 +8119,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.1.tgz",
-      "integrity": "sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ=="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
+      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g=="
     },
     "babel-jest": {
       "version": "29.2.2",
@@ -8833,8 +8817,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-es": {
       "version": "4.1.0",
@@ -10154,8 +10137,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.2.0",
@@ -11403,13 +11385,6 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
-    "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
-      "peer": true
-    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -11615,8 +11590,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
       "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "test": "npm run lint && npm run jest",
-    "jest": "FORCE_COLOR=0 jest",
+    "jest": "jest",
     "lint": "eslint *.js __tests__/**/*.js && prettier --check *.js __tests__/**/*.js"
   },
   "keywords": [
@@ -26,7 +26,7 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "axe-core": "4.5.1",
+    "axe-core": "4.7.2",
     "chalk": "4.1.2",
     "jest-matcher-utils": "29.2.2",
     "lodash.merge": "4.6.2"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "test": "npm run lint && npm run jest",
-    "jest": "jest",
+    "jest": "FORCE_COLOR=0 jest",
     "lint": "eslint *.js __tests__/**/*.js && prettier --check *.js __tests__/**/*.js"
   },
   "keywords": [


### PR DESCRIPTION
This PR updates axe-core to 4.7.2, which allows combobox on button and is a requirement at our work. More information can be found at [axe-core releases](https://github.com/dequelabs/axe-core/releases).

## [4.7.0](https://github.com/dequelabs/axe-core/releases/tag/v4.7.0)

This release adds support for a few features that have been added to browsers in the last year. No new rules are added, and it did not make axe-core stricter in any other significant way. The number of issues reported by this version may be lower than from the prior version. Of one rule, the impact level was raised.

## [4.6.0](https://github.com/dequelabs/axe-core/releases/tag/v4.6.0)

This release adds requirements introduced in WAI-ARIA 1.2, which can result in new issues. The color contrast rule has been improved which should reduce the number of incomplete (aka "needs review") results.

Lastly, this release adds the ability to include or exclude elements inside shadow DOM trees from a test run.

