### PR TITLE
feat: Upgrade axe-core to v4.9.0 latest

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -19,7 +19,7 @@ Fix any of the following:
   Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/image-alt?application=axeAPI
 
 ────────
 
@@ -35,7 +35,7 @@ Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.9/region?application=axeAPI"
 `;
 
 exports[`jest-axe toHaveNoViolations returns correctly formatted message when violations are present 1`] = `
@@ -80,7 +80,7 @@ Fix any of the following:
   Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/image-alt?application=axeAPI
 
 Expected the HTML found at $('img[src="http://example.com/2"]') to have no violations:
 
@@ -98,7 +98,7 @@ Fix any of the following:
   Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/image-alt?application=axeAPI
 
 ────────
 
@@ -120,7 +120,7 @@ Fix any of the following:
   Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/label?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/label?application=axeAPI
 
 ────────
 
@@ -142,7 +142,7 @@ Fix any of the following:
   Element has no title attribute
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/link-name?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/link-name?application=axeAPI
 
 Expected the HTML found at $('a[href$="#link-name-2"]') to have no violations:
 
@@ -162,7 +162,7 @@ Fix any of the following:
   Element has no title attribute
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/link-name?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/link-name?application=axeAPI
 
 ────────
 
@@ -178,7 +178,7 @@ Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/region?application=axeAPI
 
 Expected the HTML found at $('img[src="http://example.com/2"]') to have no violations:
 
@@ -192,7 +192,7 @@ Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/region?application=axeAPI
 
 Expected the HTML found at $('input') to have no violations:
 
@@ -206,5 +206,5 @@ Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.9/region?application=axeAPI"
 `;

--- a/__tests__/__snapshots__/reactjs.test.js.snap
+++ b/__tests__/__snapshots__/reactjs.test.js.snap
@@ -19,7 +19,7 @@ Fix any of the following:
   Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.9/image-alt?application=axeAPI"
 `;
 
 exports[`React renders correctly 1`] = `
@@ -41,7 +41,7 @@ Fix any of the following:
   Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/image-alt?application=axeAPI
 
 ────────
 
@@ -57,5 +57,5 @@ Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.9/region?application=axeAPI"
 `;

--- a/__tests__/__snapshots__/vuejs.test.js.snap
+++ b/__tests__/__snapshots__/vuejs.test.js.snap
@@ -19,7 +19,7 @@ Fix any of the following:
   Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.9/image-alt?application=axeAPI"
 `;
 
 exports[`Vue renders correctly 1`] = `
@@ -41,7 +41,7 @@ Fix any of the following:
   Element's default semantics were not overridden with role="none" or role="presentation"
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/image-alt?application=axeAPI
+https://dequeuniversity.com/rules/axe/4.9/image-alt?application=axeAPI
 
 ────────
 
@@ -57,5 +57,5 @@ Fix any of the following:
   Some page content is not contained by landmarks
 
 You can find more information on this issue here: 
-https://dequeuniversity.com/rules/axe/4.7/region?application=axeAPI"
+https://dequeuniversity.com/rules/axe/4.9/region?application=axeAPI"
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
-        "axe-core": "4.7.2",
+        "axe-core": "^4.9.0",
         "chalk": "4.1.2",
         "jest-matcher-utils": "29.2.2",
         "lodash.merge": "4.6.2"
@@ -1706,8 +1706,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.7.2",
-      "license": "MPL-2.0",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.0.tgz",
+      "integrity": "sha512-H5orY+M2Fr56DWmMFpMrq5Ge93qjNdPVqzBv5gWK3aD1OvjBEJlEzxf09z93dGVQeI0LiW+aCMIx1QtShC/zUw==",
       "engines": {
         "node": ">=4"
       }
@@ -7391,7 +7392,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.7.2"
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.0.tgz",
+      "integrity": "sha512-H5orY+M2Fr56DWmMFpMrq5Ge93qjNdPVqzBv5gWK3aD1OvjBEJlEzxf09z93dGVQeI0LiW+aCMIx1QtShC/zUw=="
     },
     "babel-jest": {
       "version": "29.6.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "axe-core": "4.7.2",
+    "axe-core": "^4.9.0",
     "chalk": "4.1.2",
     "jest-matcher-utils": "29.2.2",
     "lodash.merge": "4.6.2"


### PR DESCRIPTION
Hello. I'm requesting to update your library's `axe-core` dependency to latest `v4.9.0` as of 10 April, 2024. I took the following steps to ensure the update worked correctly:

1. Bumped the dependency by calling `npm install axe-core@latest --save`
2. `npm run test` to run your lint and snapshot tests
3. Updated snapshots
4. Ran the test suite again and ensured all items passed

Please let me know if there are additional contribution requirements and I'll update my PR. Thank you.