### PR TITLE
Bump axe-core from 4.9.1 to 4.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">= 16.0.0"
   },
   "dependencies": {
-    "axe-core": "4.9.1",
+    "axe-core": "4.10.2",
     "chalk": "4.1.2",
     "jest-matcher-utils": "29.2.2",
     "lodash.merge": "4.6.2"


### PR DESCRIPTION
This PR just bumps the **axe-core** dependency from version `4.9.1` to `4.10.2` (latest).

Specifically, this was motivated by a change in axe-core `v4.10.1` that allows label elements to provide accessibility names for button elements.

```html
<label for="123">Agree</label>
<button id="123" role="checkbox"></button>
```